### PR TITLE
Fix package footer

### DIFF
--- a/scf-mode.el
+++ b/scf-mode.el
@@ -155,4 +155,4 @@ overlay onto `scf-invisible-overlays'."
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; scf-mode.el ends here
+;;; scf-mode.el ends here


### PR DESCRIPTION
Footer requires three semicolons, not two.
